### PR TITLE
.envのDB接続設定をsetupタスクで各環境に適した値に更新するように変更

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ setup/docker:
 
 setup/conoha:
 	cp .env.example .env
+	$(eval MYSQL_PASS=$(shell sed -n 7p /etc/motd | cut -d " " -f 3))
+	@sed -i '/DB_PASSWORD=/s/$$/$(MYSQL_PASS)/g' .env
 	composer install && php artisan key:generate && make db/setup
 	sudo cp -b -f ./setup/httpd/conf/httpd.conf /etc/httpd/conf/
 	chown apache:apache /var/www/html/gtb-web-application-framework/storage/logs/

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ setup/docker:
 setup/conoha:
 	cp .env.example .env
 	$(eval MYSQL_PASS=$(shell sed -n 7p /etc/motd | cut -d " " -f 3))
-	@sed -i '/DB_PASSWORD=/s/$$/$(MYSQL_PASS)/g' .env
+	@sed -i 's/DB_HOST=127.0.0.1/DB_HOST=localhost/' .env
+	@sed -i 's/DB_PASSWORD=/DB_PASSWORD=$(MYSQL_PASS)/' .env
 	composer install && php artisan key:generate && make db/setup
 	sudo cp -b -f ./setup/httpd/conf/httpd.conf /etc/httpd/conf/
 	chown apache:apache /var/www/html/gtb-web-application-framework/storage/logs/

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ BOLD=\033[1m
 
 setup/docker:
 	cp .env.example .env
-	@sed -i 's/DB_HOST=127.0.0.1/DB_HOST=mysql/' .env
-	@sed -i 's/DB_PASSWORD=/DB_PASSWORD=root/' .env
+	@sed -i -e 's/^DB_HOST=127.0.0.1$$/DB_HOST=mysql/' .env
+	@sed -i -e 's/^DB_PASSWORD=$$/DB_PASSWORD=root/' .env
 	docker-compose up -d
 	docker-compose run php bash -c "composer install && php artisan key:generate && make db/setup"
 	@echo "$(INFO_COLOR)Setup is finished🎉$(RESET)"
@@ -17,8 +17,8 @@ setup/docker:
 setup/conoha:
 	cp .env.example .env
 	$(eval MYSQL_PASS=$(shell sed -n 7p /etc/motd | cut -d " " -f 3))
-	@sed -i 's/DB_HOST=127.0.0.1/DB_HOST=localhost/' .env
-	@sed -i 's/DB_PASSWORD=/DB_PASSWORD=$(MYSQL_PASS)/' .env
+	@sed -i -e 's/^DB_HOST=127.0.0.1$$/DB_HOST=localhost/' .env
+	@sed -i -e 's/^DB_PASSWORD=$$/DB_PASSWORD=$(MYSQL_PASS)/' .env
 	composer install && php artisan key:generate && make db/setup
 	sudo cp -b -f ./setup/httpd/conf/httpd.conf /etc/httpd/conf/
 	chown apache:apache /var/www/html/gtb-web-application-framework/storage/logs/

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ BOLD=\033[1m
 
 setup/docker:
 	cp .env.example .env
+	@sed -i 's/DB_HOST=127.0.0.1/DB_HOST=mysql/' .env
+	@sed -i 's/DB_PASSWORD=/DB_PASSWORD=root/' .env
 	docker-compose up -d
 	docker-compose run php bash -c "composer install && php artisan key:generate && make db/setup"
 	@echo "$(INFO_COLOR)Setup is finished🎉$(RESET)"
@@ -27,6 +29,8 @@ setup/conoha:
 	@echo "$(INFO_COLOR)Enjoy your development!!🥳$(RESET)"
 
 db/setup:
+	$(eval include .env)
+	$(eval export sed 's/=.*//' .env)
 	mysql -u${DB_USERNAME} -p${DB_PASSWORD} -h${DB_HOST} -e 'create database if not exists ${DB_DATABASE};'
 	php artisan migrate
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,12 +4,7 @@ services:
     php:
         build: ./docker/php
         environment:
-            DB_HOST: mysql
-            DB_PORT: 3306
-            DB_DATABASE: laravel
             DB_DATABASE_TEST: laravel_test
-            DB_USERNAME: root
-            DB_PASSWORD: root
             TZ: 'Asia/Tokyo'
             DOCKER: 1
         volumes:

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -14,7 +14,7 @@ class ExampleTest extends TestCase
      */
     public function testBasicTest()
     {
-        $response = $this->get('/');
+        $response = $this->get('/tester');
 
         $response->assertStatus(200);
     }


### PR DESCRIPTION
掲題の通り。

ConoHa のDBパスワードは `/etc/motd` に記載されている。
ので、setupタスクを実行する際に `.env` に追記するようにして、手順を一つ減らします。